### PR TITLE
update cipher suite, enable hsts

### DIFF
--- a/nginx.conf
+++ b/nginx.conf
@@ -101,11 +101,15 @@ http {
         ssl_protocols TLSv1.1 TLSv1.2;      # TLSv1.0 prevented for PCI-DSS compliance
         ssl_session_cache shared:SSL:60m;
         ssl_session_timeout 60m;
-        ssl_ciphers ECDH+AESGCM:DH+AESGCM:ECDH+AES256:DH+AES256:ECDH+AES128:DH+AES:ECDH+3DES:DH+3DES:RSA+AESGCM:RSA+AES:RSA+3DES:!aNULL:!MD5;
+        # Updated Cipher Suites
+        ssl_ciphers 'ECDHE-ECDSA-CHACHA20-POLY1305:ECDHE-RSA-CHACHA20-POLY1305:ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384:DHE-RSA-AES128-GCM-SHA256:DHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-AES128-SHA256:ECDHE-RSA-AES128-SHA256:ECDHE-ECDSA-AES128-SHA:ECDHE-RSA-AES256-SHA384:ECDHE-RSA-AES128-SHA:ECDHE-ECDSA-AES256-SHA384:ECDHE-ECDSA-AES256-SHA:ECDHE-RSA-AES256-SHA:DHE-RSA-AES128-SHA256:DHE-RSA-AES128-SHA:DHE-RSA-AES256-SHA256:DHE-RSA-AES256-SHA:AES128-GCM-SHA256:AES256-GCM-SHA384:AES128-SHA256:AES256-SHA256:AES128-SHA:AES256-SHA:!DSS';
         ssl_prefer_server_ciphers on;
 
+        # Enable HSTS
+        add_header Strict-Transport-Security max-age=15768000;
+
         # OCSP Setup
-        # To test locally: openssl s_client -connect 127.0.0.1:443 -tls1_2 -tlsextdebug -status
+        # To test locally:
         # (This test can be positive and a bad ssl_trusted_certificate pem can still break OCSP.)
         #
         # And look for this:


### PR DESCRIPTION
Updated Cipher Suites to match the latest changes.
Disabled Suites
1. TLS_RSA_WITH_3DES_EDE_CBC_SHA 
2. TLS_DHE_DSS_WITH_3DES_EDE_CBC_SHA

Added HSTS for added Security.